### PR TITLE
タグの直前かタグに挟まれた1文字のテキストが欠落する問題を修正

### DIFF
--- a/aizome-core/src/commonMain/kotlin/net/iseteki/aizome/parser/parseToSegments.kt
+++ b/aizome-core/src/commonMain/kotlin/net/iseteki/aizome/parser/parseToSegments.kt
@@ -46,7 +46,7 @@ internal fun parseToSegments(string: String, logger: ParserLogger): List<ParserS
 
         // タグまでの文字列をセグメントに追加する
         val textRange = i until startTagRange
-        if (textRange.first < textRange.last) {
+        if (i < startTagRange) {
             appendTextSegment(
                 string.substring(textRange.first, textRange.last+1),
                 styles = styleStack,

--- a/aizome-core/src/test/kotlin/net/iseteki/aizome/parser/ParseParameterStringsTest.kt
+++ b/aizome-core/src/test/kotlin/net/iseteki/aizome/parser/ParseParameterStringsTest.kt
@@ -93,6 +93,23 @@ class ParseParameterStringsTest {
         runTest(input, expect)
     }
 
+    @Test
+    fun parsesComplexesFormat() {
+        val input = listOf(
+            ParserSegment.Text("a", emptyList()),
+            ParserSegment.Text("%d-%d", listOf("bold", "red")),
+            ParserSegment.Text("c", emptyList()),
+        )
+        val expect = listOf(
+            ParserSegment.Text("a", emptyList()),
+            ParserSegment.Placeholder("%d", "%d", 0, listOf("bold", "red")),
+            ParserSegment.Text("-", listOf("bold", "red")),
+            ParserSegment.Placeholder("%d", "%d", 1, listOf("bold", "red")),
+            ParserSegment.Text("c", emptyList())
+        )
+        runTest(input, expect)
+    }
+
     private fun runTest(
         input: List<ParserSegment>,
         expect: List<ParserSegment>,

--- a/aizome-core/src/test/kotlin/net/iseteki/aizome/parser/ParseToSegmentsTest.kt
+++ b/aizome-core/src/test/kotlin/net/iseteki/aizome/parser/ParseToSegmentsTest.kt
@@ -85,6 +85,58 @@ class ParseToSegmentsTest {
     }
 
     @Test
+    fun parsesSingleCharacterInsideTag() {
+        val logger = TestParserLogger()
+        val segments = parseToSegments("<red>1</red>", logger)
+
+        assertEquals(1, segments.size)
+        val segment = segments[0] as ParserSegment.Text
+        assertEquals("1", segment.string)
+        assertEquals(listOf("red"), segment.styles)
+        assertTrue(logger.warnings.isEmpty())
+    }
+
+    @Test
+    fun parsesSingleCharacterBetweenTags() {
+        val logger = TestParserLogger()
+        val segments = parseToSegments("<red>a<blue>b</blue>c</red>", logger)
+
+        assertEquals(3, segments.size)
+
+        val s0 = segments[0] as ParserSegment.Text
+        assertEquals("a", s0.string)
+        assertEquals(listOf("red"), s0.styles)
+
+        val s1 = segments[1] as ParserSegment.Text
+        assertEquals("b", s1.string)
+        assertEquals(listOf("red", "blue"), s1.styles)
+
+        val s2 = segments[2] as ParserSegment.Text
+        assertEquals("c", s2.string)
+        assertEquals(listOf("red"), s2.styles)
+
+        assertTrue(logger.warnings.isEmpty())
+    }
+
+    @Test
+    fun parsesSingleCharacterBetweenSiblingTags() {
+        val logger = TestParserLogger()
+        val segments = parseToSegments("<bold>a</bold><red>b</red>", logger)
+
+        assertEquals(2, segments.size)
+
+        val s0 = segments[0] as ParserSegment.Text
+        assertEquals("a", s0.string)
+        assertEquals(listOf("bold"), s0.styles)
+
+        val s1 = segments[1] as ParserSegment.Text
+        assertEquals("b", s1.string)
+        assertEquals(listOf("red"), s1.styles)
+
+        assertTrue(logger.warnings.isEmpty())
+    }
+
+    @Test
     fun warnsOnUnopenedClosingTag() {
         val logger = TestParserLogger()
         parseToSegments("Hello</blue>", logger)

--- a/aizome-core/src/test/kotlin/net/iseteki/aizome/parser/ParseToSegmentsTest.kt
+++ b/aizome-core/src/test/kotlin/net/iseteki/aizome/parser/ParseToSegmentsTest.kt
@@ -63,6 +63,28 @@ class ParseToSegmentsTest {
     }
 
     @Test
+    fun parsesComplexesWithFormat() {
+        val logger = TestParserLogger()
+        val segments = parseToSegments("a<bold><red>%d-%d</red></bold>c", logger)
+
+        assertEquals(3, segments.size)
+
+        val s0 = segments[0] as ParserSegment.Text
+        assertEquals("a", s0.string)
+        assertTrue(s0.styles.isEmpty())
+
+        val s1 = segments[1] as ParserSegment.Text
+        assertEquals("%d-%d", s1.string)
+        assertEquals(listOf("bold", "red"), s1.styles)
+
+        val s2 = segments[2] as ParserSegment.Text
+        assertEquals("c", s2.string)
+        assertTrue(s2.styles.isEmpty())
+
+        assertTrue(logger.warnings.isEmpty())
+    }
+
+    @Test
     fun warnsOnUnopenedClosingTag() {
         val logger = TestParserLogger()
         parseToSegments("Hello</blue>", logger)


### PR DESCRIPTION
## 問題

以下のようなテキストで、先頭の文字が欠落する

- 文字列の先頭が1文字で、すぐにタグが出現する
- タグに挟まれているのが1文字

例: →約が欠落してしまう

```
約<bold>20</bold>分
```

## 修正

タグまでの文字列をセグメントに追加する判定の式を変更